### PR TITLE
fix(pluginsdk): Prevent command injection in npm info calls

### DIFF
--- a/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
+++ b/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
@@ -8,7 +8,13 @@ const PLUGIN_SDK = '@spinnaker/pluginsdk';
 const PEER_DEPS = '@spinnaker/pluginsdk-peerdeps';
 
 function getLatestPackageVersion(pkg) {
-  const versionsString = execSync(`npm info ${pkg} versions`).toString();
+  // Sanitize package name to prevent command injection
+  // Valid npm package names can only contain lowercase letters, numbers, dots, hyphens, underscores, and forward slashes
+  if (!/^[@a-z0-9._\-\/]+$/i.test(pkg)) {
+    throw new Error(`Invalid package name: ${pkg}`);
+  }
+  
+  const versionsString = execSync(`npm info ${JSON.stringify(pkg)} versions`).toString();
   return JSON.parse(versionsString.replace(/'/g, '"')).pop();
 }
 


### PR DESCRIPTION
## Summary
- Add input validation for package names using regex pattern to ensure only valid npm package name characters are allowed
- Sanitize package name parameter with JSON.stringify() when passing to execSync
- Addresses Semgrep rule for command injection vulnerability in child_process calls

## Changes Made
- Enhanced `getLatestPackageVersion()` function in `packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js`
- Added regex validation: `/^[@a-z0-9._\-\/]+$/i` to validate npm package names
- Used `JSON.stringify()` to properly escape the package name parameter
- Added error handling for invalid package names

## Test Plan
- [x] Verify the fix prevents command injection attempts
- [x] Ensure valid npm package names continue to work correctly
- [x] Test with scoped packages (e.g., `@spinnaker/pluginsdk`)
- [x] Validate error handling for malformed package names

🤖 Generated with [Claude Code](https://claude.ai/code)